### PR TITLE
Add link to barrier for kb & mouse sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,7 +988,7 @@ Hopefully your results are as good as mine, if not better!
         <a href="#return10"><sup>&#x21ba;</sup></a>
     </li>
     <li name="footnote11">
-        See <a href="https://heiko-sieger.info/running-windows-10-on-linux-using-kvm-with-vga-passthrough/#About_keyboard_and_mouse">this link</a> for software/hardware solutions that share your keyboard and mouse across your host and guest.
+        See <a href="https://heiko-sieger.info/running-windows-10-on-linux-using-kvm-with-vga-passthrough/#About_keyboard_and_mouse">this link</a> and <a href="https://github.com/debauchee/barrier"> this</a> for software/hardware solutions that share your keyboard and mouse across your host and guest.
         <a href="#return11"><sup>&#x21ba;</sup></a>
     </li>
     <li name="footnote12">


### PR DESCRIPTION
I saw the link for kb & mouse sharing solutions, barrier is an open source alternative to Synergy that works quite well. Thought I'd add a link to it in your footnotes.

https://github.com/debauchee/barrier