### PR TITLE
Clarify need for MEMORY= and how to calculate

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,17 @@ source "/etc/libvirt/hooks/kvm.conf"
 echo 0 > /proc/sys/vm/nr_hugepages
 ```
 
+Be sure to update your kvm.conf to include `MEMORY=<size in mb>` as the `alloc_hugepages.sh` script requires a value here. To calculate your hugepages, you can use the following commands to see your total memory and your hugepage size:
+
+```
+$ grep MemTotal /proc/meminfo
+MemTotal: 132151496 kB
+$ grep Hugepagesize /proc/meminfo
+Hugepagesize:       2048 kB
+```
+
+You will want to set `MEMORY=` to a multiple of your hugepage size in MB. From the example above: size = 2048 kB and we want roughly 16GB of memory, so we can choose `MEMORY=16384` (2048 * 8000 / 1000 = 16384).
+
 <h4>
     CPU Governor
 </h4>


### PR DESCRIPTION
Hi!

I really appreciated your guide when setting up my machine for GPU pass through. Thanks for all of the work on this!

I (and maybe a couple of others from the issues) found it a tad confusing setting up the hugepages because of the missing call out to add `MEMORY=` into the `kvm.conf` file - thought it is in the repo.

I just added a call out to do this and also a blurb about how to calculate the number that goes into that var. 

What do you think?